### PR TITLE
Nested types can have the new keyword

### DIFF
--- a/csharp-impl/src/org/mustbe/consulo/csharp/ide/highlight/check/impl/CS0106.java
+++ b/csharp-impl/src/org/mustbe/consulo/csharp/ide/highlight/check/impl/CS0106.java
@@ -61,7 +61,7 @@ public class CS0106 extends CompilerCheck<DotNetModifierListOwner>
 		NestedEnum(CSharpModifier.PUBLIC, CSharpModifier.PROTECTED, CSharpModifier.PRIVATE, CSharpModifier.INTERNAL),
 		NamespaceType(CSharpModifier.STATIC, CSharpModifier.PUBLIC, CSharpModifier.PROTECTED, CSharpModifier.INTERNAL, CSharpModifier.ABSTRACT, CSharpModifier.PARTIAL, CSharpModifier.SEALED),
 		NestedType(CSharpModifier.PUBLIC, CSharpModifier.PRIVATE, CSharpModifier.PROTECTED, CSharpModifier.INTERNAL, CSharpModifier.ABSTRACT, CSharpModifier.PARTIAL, CSharpModifier.SEALED,
-				CSharpModifier.STATIC),
+				CSharpModifier.STATIC, CSharpModifier.NEW),
 		Unknown
 				{
 					@Override


### PR DESCRIPTION
Example:

```
public class Base
{
    public class State
    {
    }
}

public class Test : Base
{
    public new class State : Base.State
    {
    }
}
```